### PR TITLE
Don't enable ADB by default on userdebug builds

### DIFF
--- a/tools/post_process_props.py
+++ b/tools/post_process_props.py
@@ -40,9 +40,8 @@ def mangle_build_prop(prop, overrides):
 # Put the modifications that you need to make into the /default.prop into this
 # function. The prop object has get(name) and put(name,value) methods.
 def mangle_default_prop(prop):
-  # If ro.debuggable is 1, then enable adb on USB by default
-  # (this is for userdebug builds)
-  if prop.get("ro.debuggable") == "1":
+  # If ro.build.type is eng, then enable adb on USB by default
+  if prop.get("ro.build.type") == "eng":
     val = prop.get("persist.sys.usb.config")
     if val == "":
       val = "adb"


### PR DESCRIPTION
Change-Id: I33ae5c6f2787017a62e679aa0c28d4b909d45935